### PR TITLE
Remove `const` declaration in favor of `var` declaration in order to support non-ES6 environments (Internet Explorer 10).

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-const md5 = require('imports?md5=>{}!exports?md5!./js-crypto/md5');
+var md5 = require('imports?md5=>{}!exports?md5!./js-crypto/md5');
 module.exports = md5;


### PR DESCRIPTION
I noticed the `const` is not being transpiled here, causing a `Syntax Error` in Internet Explorer 10. You could transpile the `const` with Babel, but it seems simpler to just change over to `var`.

Let me know what you think, thanks.